### PR TITLE
Fix urls.py so it works with django > 1.8

### DIFF
--- a/back/taiga_contrib_saml_auth/urls.py
+++ b/back/taiga_contrib_saml_auth/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from . import views
 
 app_name = 'taiga_contrib_saml_auth'
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^initiate-login/$', views.initiate_login, name="login_initiate"),
     url(r'^complete-login/$', views.complete_login, name="login_complete"),
     url(r'^initiate-logout/$', views.initiate_logout, name="logout_initiate"),
     url(r'^complete-logout/$', views.complete_logout, name="logout_complete"),
     url(r'^metadata/$', views.metadata, name="metadata"),
-)
+]


### PR DESCRIPTION
The django.conf.urls.patterns function was removed in django.

Fixes jgiannuzzi/taiga-contrib-saml-auth#1

Improves pull request #3  