### PR TITLE
fix: Onelogin expects `entityId`, case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SAML_AUTH = {
     # These settings can be found in their metadata
     'idp': {
         # Identifier of the IdP entity  (must be a URI)
-        'entityID': 'YOUR_IDP_ENTITY_ID',
+        'entityId': 'YOUR_IDP_ENTITY_ID',
 
         # SSO endpoint info of the IdP. (Authentication Request protocol)
         "singleSignOnService": {


### PR DESCRIPTION
Works like a charm! *once* you fix the readme config that is ;)

Onelogin expects the `entityId` field in exactly that format, the old `entityID` format would cause an error

this just fixes that <3